### PR TITLE
fix: board, main 페이지 접근 허용 설정 수정

### DIFF
--- a/src/main/java/com/ateam/jjimppong_back/config/WebSecurityConfig.java
+++ b/src/main/java/com/ateam/jjimppong_back/config/WebSecurityConfig.java
@@ -58,8 +58,8 @@ public class WebSecurityConfig {
     // description: 인가 설정 //
     .authorizeHttpRequests(request -> request
         .requestMatchers("/api/v1/auth", "/api/v1/auth/**", "/oauth2/**").permitAll()
-        .requestMatchers("/file/**", "/api/v1/open-ai").permitAll()
-        .requestMatchers("/api/v1/diary", "/api/v1/diary/**").authenticated()
+        .requestMatchers("/file/**", "/api/v1/main", "/api/v1/main/**").permitAll()
+        .requestMatchers("/api/v1/board", "/api/v1/board/**").authenticated()
         .anyRequest().authenticated()
     )
     // description: Oauth 로그인 적용 //

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,7 +7,7 @@ server.port=4000
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.datasource.url=jdbc:mysql://127.0.0.1:3306/jjimppong?serverTimezone=UTC&characterEncoding=UTF-8
 spring.datasource.username=root
-spring.datasource.password=rifkfkd1879!
+spring.datasource.password=root
 
 
 #! OAuth 클라이언트 주소


### PR DESCRIPTION
1. requestMatchers("/api/v1/auth", "/api/v1/auth/**", "/oauth2/**").permitAll()
/api/v1/auth 및 하위 경로 (ex: /api/v1/auth/login, /api/v1/auth/email-auth)
/oauth2/** 경로 (소셜 로그인 관련)
👉 인증 없이 누구나 접근 허용 (로그인 필요 없음)

2. requestMatchers("/file/**", "/api/v1/main", "/api/v1/main/**").permitAll()
/file/** → 파일 다운로드나 업로드 미리보기 등
/api/v1/main 및 하위 경로
👉 비회원도 접근 가능한 공개 페이지

3. requestMatchers("/api/v1/board", "/api/v1/board/**").authenticated()
/api/v1/board와 그 하위 경로 (ex: 게시글 작성, 수정 등)
👉 로그인된 사용자만 접근 가능

4. anyRequest().authenticated()
위에서 명시하지 않은 모든 다른 요청
ex: /api/v1/mypage, /admin/**, /settings 등
👉 기본적으로 로그인 필요