### PR TITLE
fix: 아이디 찾기 수정-sns사용자 제외

### DIFF
--- a/src/main/java/com/ateam/jjimppong_back/common/dto/response/ResponseCode.java
+++ b/src/main/java/com/ateam/jjimppong_back/common/dto/response/ResponseCode.java
@@ -14,6 +14,8 @@ public interface ResponseCode {
     String PASSWORD_NOT_MATCHED = "PN";
     String USER_NOT_FOUND = "UF";
     String SNS_NEED_INFO = "SNI";
+    String NOT_EXIST_USER = "NEU";
+    String SNS_NOT_FOUND = "SNF";
     
     String NO_PERMISSION = "NP";
 

--- a/src/main/java/com/ateam/jjimppong_back/common/dto/response/ResponseDto.java
+++ b/src/main/java/com/ateam/jjimppong_back/common/dto/response/ResponseDto.java
@@ -104,4 +104,14 @@ public class ResponseDto {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
     }
 
+    public static ResponseEntity<ResponseDto> notExistUser(){
+        ResponseDto body = new ResponseDto(ResponseCode.NOT_EXIST_USER, ResponseMessage.NOT_EXIST_USER);
+        return ResponseEntity.status(HttpStatus.OK).body(body);
+    }
+
+    public static ResponseEntity<ResponseDto> snsNotFound(){
+        ResponseDto body = new ResponseDto(ResponseCode.SNS_NOT_FOUND, ResponseMessage.SNS_NOT_FOUND);
+        return ResponseEntity.status(HttpStatus.OK).body(body);
+    }
+
 }

--- a/src/main/java/com/ateam/jjimppong_back/common/dto/response/ResponseMessage.java
+++ b/src/main/java/com/ateam/jjimppong_back/common/dto/response/ResponseMessage.java
@@ -14,6 +14,8 @@ public interface ResponseMessage {
     String PASSWORD_NOT_MATCHED = "Password Not Matched";
     String USER_NOT_FOUND = "User Not Found";
     String SNS_NEED_INFO = "Sns Need Info";
+    String NOT_EXIST_USER = "Not Exist User";
+    String SNS_NOT_FOUND = "Sns Not Found";
     
     String NO_PERMISSION = "No Permission.";
 

--- a/src/main/java/com/ateam/jjimppong_back/service/implement/AuthServiceImplement.java
+++ b/src/main/java/com/ateam/jjimppong_back/service/implement/AuthServiceImplement.java
@@ -191,7 +191,17 @@ public class AuthServiceImplement implements AuthService{
             }
 
             // 사용자 이름과 이메일로 사용자 정보 찾기
-            UserEntity userEntity = userRepository.findByNameAndUserEmail(name, userEmail);       
+            UserEntity userEntity = userRepository.findByNameAndUserEmail(name, userEmail);     
+            
+            // 사용자 존재 여부 확인
+            if (userEntity == null) {
+                return ResponseDto.notExistUser(); // 사용자 없음
+            }
+
+            // SNS 사용자 여부 확인
+            if (!"NORMAL".equalsIgnoreCase(userEntity.getJoinType())) {
+                return ResponseDto.snsNotFound(); // SNS 사용자는 아이디 찾기 불가
+            }
 
             // 아이디 반환
             return IdSearchResponseDto.success(userEntity.getUserId());

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,7 +7,7 @@ server.port=4000
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.datasource.url=jdbc:mysql://127.0.0.1:3306/mydb?serverTimezone=UTC&characterEncoding=UTF-8
 spring.datasource.username=root
-spring.datasource.password=rifkfkd1879!
+spring.datasource.password=root
 
 
 


### PR DESCRIPTION
fix: 아이디 찾기 수정-sns사용자 제외
SNS 사용자의 경우 
'SNF' 출력
아이디 찾기 불가

존재하지 않는 사용자의 경우
'NEU' 출력
아이디 찾기 불가